### PR TITLE
fix(root-view): 집 주소 설정 시 main 시작, 주소 재설정 시 화면 처리

### DIFF
--- a/Sticky.xcodeproj/project.pbxproj
+++ b/Sticky.xcodeproj/project.pbxproj
@@ -37,6 +37,9 @@
 		BBB1EC8325B0887500F5EA37 /* Indicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB1EC8225B0887500F5EA37 /* Indicator.swift */; };
 		BBB1EC8E25B088EA00F5EA37 /* GradientRoundedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB1EC8D25B088EA00F5EA37 /* GradientRoundedButton.swift */; };
 		BBB1ECB825B090A900F5EA37 /* BorderRoundedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB1ECB725B090A900F5EA37 /* BorderRoundedButton.swift */; };
+		BBC66EBD25C4E965007687D7 /* AppMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBC66EBC25C4E965007687D7 /* AppMain.swift */; };
+		BBC66EC825C4F99E007687D7 /* TimerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBC66EC725C4F99E007687D7 /* TimerView.swift */; };
+		BBC66EDE25C5197A007687D7 /* RootPresentationMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBC66EDD25C5197A007687D7 /* RootPresentationMode.swift */; };
 		C202D59525BD365F0033B450 /* PopupMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C202D59425BD365F0033B450 /* PopupMessage.swift */; };
 		C202D5A025BD38CC0033B450 /* PopupStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C202D59F25BD38CC0033B450 /* PopupStateModel.swift */; };
 		C2228FCC25BD5EAD00C4DF0B /* MyOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2228FCB25BD5EAD00C4DF0B /* MyOperation.swift */; };
@@ -110,6 +113,9 @@
 		BBB1EC8225B0887500F5EA37 /* Indicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Indicator.swift; sourceTree = "<group>"; };
 		BBB1EC8D25B088EA00F5EA37 /* GradientRoundedButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradientRoundedButton.swift; sourceTree = "<group>"; };
 		BBB1ECB725B090A900F5EA37 /* BorderRoundedButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BorderRoundedButton.swift; sourceTree = "<group>"; };
+		BBC66EBC25C4E965007687D7 /* AppMain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppMain.swift; sourceTree = "<group>"; };
+		BBC66EC725C4F99E007687D7 /* TimerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerView.swift; sourceTree = "<group>"; };
+		BBC66EDD25C5197A007687D7 /* RootPresentationMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootPresentationMode.swift; sourceTree = "<group>"; };
 		C202D59425BD365F0033B450 /* PopupMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupMessage.swift; sourceTree = "<group>"; };
 		C202D59F25BD38CC0033B450 /* PopupStateModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupStateModel.swift; sourceTree = "<group>"; };
 		C2228FCB25BD5EAD00C4DF0B /* MyOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyOperation.swift; sourceTree = "<group>"; };
@@ -223,6 +229,7 @@
 		BB0A595725BAC23E001F529A /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				BBC66EC725C4F99E007687D7 /* TimerView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -397,6 +404,8 @@
 				C23A05A525BBE3F3007339BD /* Popup.swift */,
 				C202D59425BD365F0033B450 /* PopupMessage.swift */,
 				C202D59F25BD38CC0033B450 /* PopupStateModel.swift */,
+				BBC66EBC25C4E965007687D7 /* AppMain.swift */,
+				BBC66EDD25C5197A007687D7 /* RootPresentationMode.swift */,
 			);
 			path = Features;
 			sourceTree = "<group>";
@@ -588,6 +597,7 @@
 			files = (
 				BB1C8A2725B875020000931A /* SearchResult.swift in Sources */,
 				BB1C8A2A25B875020000931A /* NotFound.swift in Sources */,
+				BBC66EDE25C5197A007687D7 /* RootPresentationMode.swift in Sources */,
 				C202D5A025BD38CC0033B450 /* PopupStateModel.swift in Sources */,
 				BB0A596D25BAD2CF001F529A /* LinkItem.swift in Sources */,
 				BBB1EC8325B0887500F5EA37 /* Indicator.swift in Sources */,
@@ -620,6 +630,8 @@
 				C277C54525BEFC4100ADD2EC /* TimerRunning.swift in Sources */,
 				C277C53825BEF98500ADD2EC /* TimerNotRunning.swift in Sources */,
 				C277C53D25BEF9B500ADD2EC /* TimerOff.swift in Sources */,
+				BBC66EC825C4F99E007687D7 /* TimerView.swift in Sources */,
+				BBC66EBD25C4E965007687D7 /* AppMain.swift in Sources */,
 				BB1C8A2825B875020000931A /* Tip.swift in Sources */,
 				BB0A592425B9C99D001F529A /* MyPage.swift in Sources */,
 				C202D59525BD365F0033B450 /* PopupMessage.swift in Sources */,

--- a/Sticky.xcworkspace/contents.xcworkspacedata
+++ b/Sticky.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:Sticky.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Sticky.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Sticky.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Sticky.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/Sticky.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PreviewsEnabled</key>
+	<false/>
+</dict>
+</plist>

--- a/Sticky/Features/AppMain.swift
+++ b/Sticky/Features/AppMain.swift
@@ -1,0 +1,49 @@
+//
+//  AppMain.swift
+//  Sticky
+//
+//  Created by deo on 2021/01/30.
+//
+
+import SwiftUI
+
+// MARK: - AppMain
+
+struct AppMain: View {
+    // MARK: Lifecycle
+
+    init() {
+        let newNavAppearance = UINavigationBarAppearance()
+        newNavAppearance.configureWithTransparentBackground()
+        newNavAppearance.backgroundColor = .clear
+        UINavigationBar.appearance()
+            .standardAppearance = newNavAppearance
+    }
+
+    // MARK: Internal
+
+    var body: some View {
+        let rootView = UserDefaults.standard.bool(forKey: "hasGeofence") ?
+            AnyView(Main()) : AnyView(Onboarding())
+
+        NavigationView {
+            VStack {
+                NavigationLink(destination: rootView, isActive: self.$isActive) { EmptyView() }
+
+                rootView
+            }
+        }.environment(\.rootPresentationMode, self.$isActive)
+    }
+
+    // MARK: Private
+
+    @State private var isActive: Bool = true
+}
+
+// MARK: - AppMain_Previews
+
+struct AppMain_Previews: PreviewProvider {
+    static var previews: some View {
+        AppMain()
+    }
+}

--- a/Sticky/Features/Onboarding/Onboarding.swift
+++ b/Sticky/Features/Onboarding/Onboarding.swift
@@ -7,45 +7,39 @@
 
 import SwiftUI
 
+// MARK: - Onboarding
+
 struct Onboarding: View {
-    init() {
-        let newNavAppearance = UINavigationBarAppearance()
-        newNavAppearance.configureWithTransparentBackground()
-        newNavAppearance.backgroundColor = .clear
-        UINavigationBar.appearance()
-            .standardAppearance = newNavAppearance
-    }
-
     var body: some View {
-        NavigationView {
-            ZStack {
-                Color.main
-                    .ignoresSafeArea()
-                VStack {
-                    Image("logo_sticky")
-                        .padding(.bottom, 40)
-                    Text("“Sticky”는 집에서 사용하는 챌린지 서비스입니다. 집 위치를 설정하기 위해 위치정보 사용을 동의해주세요!".localized)
-                        .font(.system(size: 16))
-                        .foregroundColor(.white)
-                        .multilineTextAlignment(.center)
-                        .frame(width: 280, height: 72)
-                        .padding(.bottom, 50)
+        ZStack {
+            Color.main
+                .ignoresSafeArea()
+            VStack {
+                Image("logo_sticky")
+                    .padding(.bottom, 40)
+                Text("“Sticky”는 집에서 사용하는 챌린지 서비스입니다. 집 위치를 설정하기 위해 위치정보 사용을 동의해주세요!".localized)
+                    .font(.system(size: 16))
+                    .foregroundColor(.white)
+                    .multilineTextAlignment(.center)
+                    .frame(width: 280, height: 72)
+                    .padding(.bottom, 50)
 
-                    NavigationLink(destination: SearchAddress()) {
-                        GradientRoundedButton(
-                            content: "위치정보 설정하기".localized,
-                            startColor: Color.black,
-                            endColor: Color.black,
-                            width: 202,
-                            height: 48
-                        )
-                    }
-                }.frame(width: 280, height: 290)
-            }
-            .navigationBarTitleDisplayMode(.inline)
+                NavigationLink(destination: SearchAddress()) {
+                    GradientRoundedButton(
+                        content: "위치정보 설정하기".localized,
+                        startColor: Color.black,
+                        endColor: Color.black,
+                        width: 202,
+                        height: 48
+                    )
+                }
+            }.frame(width: 280, height: 290)
         }
+        .navigationBarTitleDisplayMode(.inline)
     }
 }
+
+// MARK: - Onboarding_Previews
 
 struct Onboarding_Previews: PreviewProvider {
     static var previews: some View {

--- a/Sticky/Features/RootPresentationMode.swift
+++ b/Sticky/Features/RootPresentationMode.swift
@@ -1,0 +1,29 @@
+//
+//  RootPresentationMode.swift
+//  Sticky
+//
+//  Created by deo on 2021/01/30.
+//
+
+import SwiftUI
+
+// MARK: - RootPresentationModeKey
+
+struct RootPresentationModeKey: EnvironmentKey {
+    static let defaultValue: Binding<RootPresentationMode> = .constant(RootPresentationMode())
+}
+
+extension EnvironmentValues {
+    var rootPresentationMode: Binding<RootPresentationMode> {
+        get { return self[RootPresentationModeKey.self] }
+        set { self[RootPresentationModeKey.self] = newValue }
+    }
+}
+
+typealias RootPresentationMode = Bool
+
+public extension RootPresentationMode {
+    mutating func dismiss() {
+        self.toggle()
+    }
+}

--- a/Sticky/Features/SearchAddress/Views/SearchResult.swift
+++ b/Sticky/Features/SearchAddress/Views/SearchResult.swift
@@ -13,6 +13,7 @@ struct SearchResult: View {
     // MARK: Internal
 
     @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
+    @Environment(\.rootPresentationMode) private var rootPresentationMode: Binding<RootPresentationMode>
     @EnvironmentObject var model: LocationManager
     @EnvironmentObject var locationSearchService: LocationSearchService
 
@@ -34,7 +35,17 @@ struct SearchResult: View {
                     .padding(.bottom, 46)
                 Button(action: {
                     model.setGeofenceMyHome(region: locationSearchService.region)
-                    self.selection = "main"
+                    let hasGeofence = UserDefaults.standard.bool(forKey: "hasGeofence")
+                    UserDefaults.standard.setValue(true, forKey: "hasGeofence")
+
+                    if hasGeofence {
+                        print("집 주소를 변경했습니다")
+                        self.rootPresentationMode.wrappedValue.dismiss()
+                    } else {
+                        print("집 주소를 등록했습니다")
+                        self.selection = "main"
+                    }
+
                 }) {
                     GradientRoundedButton(
                         content: "집으로 설정하기".localized,

--- a/Sticky/Features/Timer/Components/TimerView.swift
+++ b/Sticky/Features/Timer/Components/TimerView.swift
@@ -1,0 +1,47 @@
+//
+//  TimerView.swift
+//  Sticky
+//
+//  Created by deo on 2021/01/30.
+//
+
+import SwiftUI
+
+// MARK: - TimerView
+
+struct TimerView: View {
+    @Binding var time: TimeData
+
+    var body: some View {
+        VStack {
+            Text("\(time.day)일")
+                .font(.system(size: 40))
+                .foregroundColor(.white)
+
+            Text(String(format: "%02d:%02d", time.hour, time.minute))
+                .font(.system(size: 80))
+                .bold()
+                .foregroundColor(.white)
+
+            Text(String(format: "%02d", time.second))
+                .font(.system(size: 30))
+                .foregroundColor(.white)
+        }
+    }
+}
+
+// MARK: - TimerView_Previews
+
+struct TimerView_Previews: PreviewProvider {
+    struct TimerViewWrapper: View {
+        @State var time = TimeData()
+
+        var body: some View {
+            TimerView(time: $time)
+        }
+    }
+
+    static var previews: some View {
+        TimerViewWrapper()
+    }
+}

--- a/Sticky/Features/Timer/Views/Main.swift
+++ b/Sticky/Features/Timer/Views/Main.swift
@@ -1,5 +1,5 @@
 //
-//  Timer.swift
+//  Main.swift
 //  Sticky
 //
 //  Created by deo on 2021/01/22.
@@ -30,7 +30,7 @@ struct Main: View {
     @State var color = Color.main
 
     // 매 초 간격으로 main 쓰레드에서 공통 실행 루프에서 실행
-    let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+    private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
     var body: some View {
         ZStack {
@@ -43,21 +43,9 @@ struct Main: View {
                 .ignoresSafeArea()
             VStack {
                 Spacer()
-                VStack {
-                    Text("\(time.timeData.day)일")
-                        .font(.system(size: 40))
-                        .foregroundColor(.white)
+                TimerView(time: $time.timeData)
+                    .padding(.bottom, 87)
 
-                    Text(String(format: "%02d:%02d", time.timeData.hour, time.timeData.minute))
-                        .font(.system(size: 80))
-                        .bold()
-                        .foregroundColor(.white)
-
-                    Text(String(format: "%02d", time.timeData.second))
-                        .font(.system(size: 30))
-                        .foregroundColor(.white)
-                }
-                .padding(.bottom, 87)
                 setView()
                 Spacer().frame(height: 100)
                 ScrollView(.horizontal, showsIndicators: false) {
@@ -73,6 +61,7 @@ struct Main: View {
                 .padding(.leading, 16)
                 .padding(.bottom, 20)
             }
+            .navigationBarBackButtonHidden(true)
         }
         .onReceive(timer) { _ in
             if timerClass.type == .running {
@@ -86,8 +75,6 @@ struct Main: View {
                 time.timeData.second += 1
             }
         }
-        .navigationBarBackButtonHidden(true)
-        .navigationBarItems(leading: mypageButton)
         .popup(isPresented: $popupState.isPresented, rateOfWidth: 0.8) {
             PopupMessage(
                 isPresented: $popupState.isPresented,
@@ -98,7 +85,9 @@ struct Main: View {
             ) {
                 self.sharePresented = true
             }
-        }.ignoresSafeArea(.all)
+        }
+        .ignoresSafeArea(.all)
+        .navigationBarItems(leading: mypageButton)
     }
 
     private var mypageButton: some View {

--- a/Sticky/StickyApp.swift
+++ b/Sticky/StickyApp.swift
@@ -16,7 +16,7 @@ struct StickyApp: App {
 
     var body: some Scene {
         WindowGroup {
-            Onboarding()
+            AppMain()
                 .environmentObject(PopupStateModel())
                 .environmentObject(UIStateModel())
                 .environmentObject(time)
@@ -75,6 +75,9 @@ struct StickyApp: App {
     }
 
     // MARK: Private
+
+    private var latitude = UserDefaults.standard.double(forKey: "latitude")
+    private var longitude = UserDefaults.standard.double(forKey: "longitude")
 
     @Environment(\.scenePhase) private var scenePhase
     private var time = Time()


### PR DESCRIPTION
# Issue

- 메인 화면 분기 처리

- 집 주소 재설정 버그 수정


# Changelog

### [1.8.1](https://github.com/Nexters/Sticky_iOS/compare/v1.8.0...v1.8.1) (2021-01-30)


### Bug Fixes

* **root-view:** 집 주소 설정 시 main 시작, 주소 재설정 시 화면 처리 ([f938b46](https://github.com/Nexters/Sticky_iOS/commit/f938b4636961d7b1595c8061221980e2e4dffe47))

---

<details open> <summary>스크린샷</summary>

![pop-root-view](https://user-images.githubusercontent.com/15080806/106347777-42670980-6304-11eb-8c0d-b72aba2b9826.gif)

</details>
